### PR TITLE
Change service to start after cloud-config.service

### DIFF
--- a/debian/userconf-pi.userconfig.service
+++ b/debian/userconf-pi.userconfig.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=User configuration dialog
-After=systemd-user-sessions.service cloud-config.target
+After=systemd-user-sessions.service cloud-config.service
 Before=lightdm.service
 [Service]
 Type=oneshot


### PR DESCRIPTION
The config service also changes locale, timezone and keyboard stuff and potential reboots by `cc_raspberry_pi` to apply `config.txt` changes requested by the user.

@tdewey-rpi