### PR TITLE
Using an existing username breaks the process, and you can never change the account again.

### DIFF
--- a/userconf
+++ b/userconf
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e 
+
 rename_user () {
     usermod -l "$NEWNAME" "$FIRSTUSER"
     usermod -m -d "/home/$NEWNAME" "$NEWNAME"

--- a/userconf-service
+++ b/userconf-service
@@ -19,6 +19,10 @@ validate_user() {
         MSG="$MSG\nCannot be root."
         RET=1
     fi
+    if getent passwd "$NEW_USER" >/dev/null 2>&1; then
+        MSG="$MSG\nCannot use existing username '$NEW_USER'."
+        RET=1
+    fi
     if [ "$RET" -ne 0 ]; then
         echo "$MSG"
     fi


### PR DESCRIPTION
When doing testing and validation of the Trixie release for[ homebridge ](https://github.com/homebridge/homebridge-raspbian-image) found that if you use an existing account the process errored and never attempted again.  So added two controls

1 - Added set -e to `userconf` to have it fail during an error.  This is last resort, and will leave the RPI redoing userconf instead of just continuing.

2 - Added an existing account check `userconf-service`